### PR TITLE
[refact] StringWithCountingNumber numberUnit 추가 # 17

### DIFF
--- a/src/components/atoms/CountingNumber.tsx
+++ b/src/components/atoms/CountingNumber.tsx
@@ -44,7 +44,7 @@ export default function CountingNumber({
     };
 
     // 초기속도: 마지막, 두번째 속도를 정한 후 역으로 계산.
-    // 계산식  =  남은 시간 / 남은 개수 / 증가하는 수의 단위
+    // 계산식  =  남은 시간 / 남은 개수 * 증가하는 수의 단위
     const firstSpeed =
       ((totalTimes -
         (restCount.last * speeds.last) / units.last -

--- a/src/components/molecules/StringWithCountingNumber.tsx
+++ b/src/components/molecules/StringWithCountingNumber.tsx
@@ -7,6 +7,7 @@ import CountingNumber, { CountingNumberProps } from "../atoms/CountingNumber";
 
 export interface StringWithCountingNumberProps extends BaseProps {
   number: CountingNumberProps["number"];
+  numberUnit?: string;
   unit: string;
 }
 
@@ -23,6 +24,7 @@ const CountingNumberWrapper = styled.strong`
 
 export default function StringWithCountingNumber({
   number,
+  numberUnit,
   unit,
   children,
   ...rest
@@ -30,7 +32,9 @@ export default function StringWithCountingNumber({
   return (
     <StringWithCountingNumberStyled {...rest}>
       <CountingNumberWrapper>
-        <CountingNumber number={number} />만 {unit}
+        <CountingNumber number={number} />
+        {numberUnit && `${numberUnit} `}
+        {unit}
       </CountingNumberWrapper>
       {children}
     </StringWithCountingNumberStyled>

--- a/src/components/molecules/StringWithCountingNumber.tsx
+++ b/src/components/molecules/StringWithCountingNumber.tsx
@@ -7,8 +7,8 @@ import CountingNumber, { CountingNumberProps } from "../atoms/CountingNumber";
 
 export interface StringWithCountingNumberProps extends BaseProps {
   number: CountingNumberProps["number"];
-  numberUnit?: string;
   unit: string;
+  numberUnit?: string;
 }
 
 const StringWithCountingNumberStyled = styled.div`

--- a/src/components/organisms/AchievementSection.tsx
+++ b/src/components/organisms/AchievementSection.tsx
@@ -67,13 +67,13 @@ export default function AchievementSection(props: AchievementSectionProps) {
     <AchievementSectionStyled {...props}>
       <BigAwardImgStringWrapper>2021년 12월 기준</BigAwardImgStringWrapper>
       <CountingNumberWrapper>
-        <StringWithCountingNumber number={700} unit="명">
+        <StringWithCountingNumber number={700} numberUnit="만" unit="명">
           의 여행자
         </StringWithCountingNumber>
-        <StringWithCountingNumber number={100} unit="개">
+        <StringWithCountingNumber number={100} numberUnit="만" unit="개">
           의 여행 리뷰
         </StringWithCountingNumber>
-        <StringWithCountingNumber number={470} unit="개">
+        <StringWithCountingNumber number={470} numberUnit="만" unit="개">
           의 여행 일정
         </StringWithCountingNumber>
       </CountingNumberWrapper>


### PR DESCRIPTION
## 설명

props에 numberUnit(숫자단위)를 추가하여 만, 천, 백 등의 단위를 자유롭게 넣을 수 있도록 하였습니다.

## 구현사항

numberUnit은 Optional 값입니다. 넣지 않을 경우에는 `200개` 같은 형식으로 나오도록 구현하였습니다.


## 사용법

외부에서 사용할 때
```
<StringWithCountingNumber number={number} numberUnit='만' unit='개'>
의 여행자
</StringWithCountingNumber>
```

## ISSUE
#17

## 기타
2000 이상의 값을 number로 넣을 경우에는 애니메이션이 해당숫자까지 도달하지 못합니다.
적절한 숫자단위를 넣어서 문제를 해결 할 수 있습니다.